### PR TITLE
get PropTypes from prop-types package instead of React

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "url": "https://github.com/yuanyan/boron.git"
   },
   "dependencies": {
-    "domkit": "^0.0.1"
+    "domkit": "^0.0.1",
+    "prop-types": "^15.6.0"
   },
   "peerDependencies": {
     "react": ">=0.14.0"

--- a/src/modalFactory.js
+++ b/src/modalFactory.js
@@ -1,4 +1,5 @@
 var React = require('react');
+var PropTypes = require('prop-types')
 var transitionEvents = require('domkit/transitionEvents');
 var appendVendorPrefix = require('domkit/appendVendorPrefix');
 
@@ -6,17 +7,17 @@ module.exports = function(animation){
 
     return React.createClass({
         propTypes: {
-            className: React.PropTypes.string,
+            className: PropTypes.string,
             // Close the modal when esc is pressed? Defaults to true.
-            keyboard: React.PropTypes.bool,
-            onShow: React.PropTypes.func,
-            onHide: React.PropTypes.func,
-            animation: React.PropTypes.object,
-            backdrop: React.PropTypes.bool,
-            closeOnClick: React.PropTypes.bool,
-            modalStyle: React.PropTypes.object,
-            backdropStyle: React.PropTypes.object,
-            contentStyle: React.PropTypes.object,
+            keyboard: PropTypes.bool,
+            onShow: PropTypes.func,
+            onHide: PropTypes.func,
+            animation: PropTypes.object,
+            backdrop: PropTypes.bool,
+            closeOnClick: PropTypes.bool,
+            modalStyle: PropTypes.object,
+            backdropStyle: PropTypes.object,
+            contentStyle: PropTypes.object,
         },
 
         getDefaultProps: function() {


### PR DESCRIPTION
See [depracation warnings](https://reactjs.org/blog/2017/04/07/react-v15.5.0.html#new-deprecation-warnings) of React 15.5.0.